### PR TITLE
fix: repo id be same with repo path

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -75,7 +75,7 @@ impl Config {
     }
 
     pub fn parse_from_env() -> Self {
-        let s = Self {
+        let mut s = Self {
             work_dir: std::env::var("WORK_DIR").unwrap_or_else(|_| default_work_dir()),
             parser_dir: std::env::var("PARSER_DIR").unwrap_or_else(|_| default_parser_dir()),
             api_type: std::env::var("API_TYPE").unwrap_or_else(|_| default_api_type()),
@@ -96,6 +96,14 @@ impl Config {
                 })
                 .unwrap_or(Language::Chinese),
         };
+        // if work_dir is not absolute path, make it absolute path
+        if !Path::new(&s.work_dir).is_absolute() {
+            s.work_dir = PathBuf::from(std::env::current_dir().unwrap())
+                .join(s.work_dir)
+                .to_str()
+                .unwrap()
+                .to_string();
+        }
         s
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -77,7 +77,10 @@ pub fn get_repo(repo_path: &String, opts: &CompressOptions) -> Result<Repository
         parse_repo(&path, opts)?
     };
 
-    match compress::from_json(&repo_path, String::from_utf8(data).unwrap().as_str()) {
+    match compress::from_json(
+        &path.to_str().unwrap(),
+        String::from_utf8(data).unwrap().as_str(),
+    ) {
         Ok(repo) => Ok(repo),
         Err(err) => Err(Error::Parse(err.to_string())),
     }


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
