### PR TITLE
fix:(lsp) cache textDocument/definition

### DIFF
--- a/lang/lsp/lsp.go
+++ b/lang/lsp/lsp.go
@@ -356,7 +356,6 @@ func (cli *LSPClient) SemanticTokens(ctx context.Context, id Location) ([]Token,
 
 	var resp SemanticTokens
 	if err := cli.getSemanticTokensRange(ctx, req, &resp, cli.Language == uniast.Cxx); err != nil {
-
 		return nil, err
 	}
 
@@ -373,6 +372,11 @@ func (cli *LSPClient) Definition(ctx context.Context, uri DocumentURI, pos Posit
 	if err != nil {
 		return nil, err
 	}
+	if f.Definitions != nil {
+		if locations, ok := f.Definitions[pos]; ok {
+			return locations, nil
+		}
+	}
 
 	// call
 	req := lsp.TextDocumentPositionParams{
@@ -385,6 +389,7 @@ func (cli *LSPClient) Definition(ctx context.Context, uri DocumentURI, pos Posit
 	if err := cli.Call(ctx, "textDocument/definition", req, &resp); err != nil {
 		return nil, err
 	}
+
 	// cache definitions
 	if f.Definitions == nil {
 		f.Definitions = make(map[Position][]Location)


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

曾经对 textDocument/definition 的 cache 实现不完全，简单加上

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
