### PR TITLE
fix: cache countLines. add comments.

### DIFF
--- a/lang/collect/export.go
+++ b/lang/collect/export.go
@@ -40,11 +40,12 @@ func (c *Collector) fileLine(loc Location) uniast.FileLine {
 		rel = filepath.Base(loc.URI.File())
 	}
 	text := c.cli.GetFile(loc.URI).Text
+	file_uri := string(loc.URI)
 	return uniast.FileLine{
 		File:        rel,
 		Line:        loc.Range.Start.Line,
-		StartOffset: lsp.PositionOffset(text, loc.Range.Start),
-		EndOffset:   lsp.PositionOffset(text, loc.Range.End),
+		StartOffset: lsp.PositionOffset(file_uri, text, loc.Range.Start),
+		EndOffset:   lsp.PositionOffset(file_uri, text, loc.Range.End),
 	}
 }
 

--- a/lang/cxx/spec.go
+++ b/lang/cxx/spec.go
@@ -166,7 +166,7 @@ func (c *CxxSpec) FunctionSymbol(sym lsp.DocumentSymbol) (int, []int, []int, []i
 	// TODO: attributes may contain parens. also inline structs.
 
 	endRelOffset := 0
-	lines := utils.CountLinesCached(sym.Text)
+	lines := utils.CountLinesPooled(sym.Text)
 	phase := 0
 	for i, tok := range sym.Tokens {
 		switch phase {

--- a/lang/lsp/utils.go
+++ b/lang/lsp/utils.go
@@ -36,7 +36,7 @@ import (
 )
 
 func GetDistance(text string, start Position, pos Position) int {
-	lines := utils.CountLinesCached(text)
+	lines := utils.CountLinesPooled(text)
 	defer utils.PutCount(lines)
 	// find the line of the position
 	return (*lines)[pos.Line-start.Line] + pos.Character - start.Character
@@ -59,13 +59,15 @@ func RelativePostionWithLines(lines []int, textPos Position, pos Position) int {
 	return lines[l] + pos.Character - textPos.Character
 }
 
-func PositionOffset(text string, pos Position) int {
+func PositionOffset(file_uri string, text string, pos Position) int {
 	if pos.Line < 0 || pos.Character < 0 {
 		log.Error("invalid text position: %+v", pos)
 		return -1
 	}
-	lines := utils.CountLinesCached(text)
-	defer utils.PutCount(lines)
+	lines := utils.CountLinesCached(file_uri, text)
+
+	// lines := utils.CountLinesPooled(text)
+	// defer utils.PutCount(lines)
 
 	return RelativePostionWithLines(*lines, Position{Line: 0, Character: 0}, pos)
 }

--- a/lang/lsp/utils_test.go
+++ b/lang/lsp/utils_test.go
@@ -73,7 +73,7 @@ func TestPositionOffset(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := PositionOffset(tt.text, tt.pos)
+			result := PositionOffset(tt.name, tt.text, tt.pos)
 			if result != tt.expected {
 				t.Errorf("PositionOffset() = %v, expected %v", result, tt.expected)
 			}

--- a/lang/rust/spec.go
+++ b/lang/rust/spec.go
@@ -261,7 +261,7 @@ func (c *RustSpec) FunctionSymbol(sym lsp.DocumentSymbol) (int, []int, []int, []
 	if where == -1 {
 		where = len(tokens) - 1
 	}
-	lines := utils.CountLinesCached(sym.Text)
+	lines := utils.CountLinesPooled(sym.Text)
 
 	// find the typeParam's type token between "fn" and "("
 	var typeParams []int


### PR DESCRIPTION
#### What type of PR is this?

经过 perf 分析，export 很慢的原因是重复对同样的 fileContent 调用 countLinesCached。
但是这个不是 cache 而是内存 pool，所以澄清了这一点并且增加了 cache。

人眼看 json 基本正确，但是无法比对因为 abcoder 输出不稳定（见 [issue](https://github.com/cloudwego/abcoder/issues/33) ）

Before

![Screenshot from 2025-06-10 20-01-14](https://github.com/user-attachments/assets/2a1c510d-ba3d-4d01-89a4-40c264832906)

After

![Screenshot from 2025-06-10 20-02-17](https://github.com/user-attachments/assets/0fd23f58-0c7f-4aea-b49a-043fdb3cfc3a)

端到端加速 20%

<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
