### PR TITLE
opt(export): remember visited to avoid redundant computation

### DIFF
--- a/lang/collect/export.go
+++ b/lang/collect/export.go
@@ -75,8 +75,8 @@ func (c *Collector) Export(ctx context.Context) (*uniast.Repository, error) {
 	c.filterLocalSymbols()
 
 	// export symbols
+	visited := make(map[*lsp.DocumentSymbol]*uniast.Identity)
 	for _, symbol := range c.syms {
-		visited := make(map[*lsp.DocumentSymbol]*uniast.Identity)
 		_, _ = c.exportSymbol(&repo, symbol, "", visited)
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
优化 export：重用 visited 防止重复 exportSymbol。

正确性因为 parser 不稳定，所以难以检验。
但肉眼检查 rust2 只有一个 Offset 的问题。

实测，对于 django__django-13551（有 30201 symbols, 9473 edges）
export 时间（除去 filterLocal 准备阶段）从原先 8s 变为 1s。

##### 以下是具体解释
export 的流程是

```
func exportSymbol(repo, sym, refname, visited) -> (id, err) {
    把 sym 加入 visited
    把 sym 对应的 fn/ty/var 变成 uniast 结点
    把 uniast 结点插入 repo.pkg.Funcs/Types/Vars
    在此过程中，对于所有依赖递归的跑 exportSymbol
}

func Export() {
    for _, symbol := range c.syms {
        visited := make(map[*lsp.DocumentSymbol]*uniast.Identity)
        _, _ = c.exportSymbol(&repo, symbol, "", visited)
    }
}
```

为什么 Export() 里 for 循环每次都要构建一个新的 visited?

给一个 sym 做 exportSymbol 的时候，就已经把 sym 的所有直接间接依赖给 exportSymbol 了。
但是照现在的做法，for 循环每次都要构建一个新的 visited，那么就会出现重复计算：
1. syma 是 symb 的依赖。
2. Export 的 for 循环中先对 symb 做了 exportSymbol ， 过程中把 syma 也做了 exportSymbol，（这个信息记录在 visited 中）
3. Export 的 for 循环再次遇到 syma，新的 visited 不知道 syma 已经 exportSymbol，于是对 syma 重复 exportSymbol，然后算出一模一样（实验确认了）的结点再存一次

如果成立，那优化一下就可以把 Export() 复杂度从 O(N**2) 变成 O(N)


#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
