### PR TITLE
fix: *ASTReadTools.GetASTNode didn't return its mod_path and pkg_path

### DIFF
--- a/llm/tool/ast_read.go
+++ b/llm/tool/ast_read.go
@@ -491,6 +491,8 @@ func (t *ASTReadTools) GetASTNode(_ context.Context, params GetASTNodeReq) (*Get
 			grps = append(grps, NewNodeID(grp.Identity))
 		}
 		resp.Nodes = append(resp.Nodes, NodeStruct{
+			ModPath:      node.Identity.ModPath,
+			PkgPath:      node.Identity.PkgPath,
 			Name:         node.Identity.Name,
 			Type:         node.Type.String(),
 			Codes:        node.Content(),


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.

修复(ast_read): 确保 NodeStruct 字段正确填充


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: Fixed a regression where NodeStruct.ModPath and NodeStruct.PkgPath were left empty when serializing AST nodes. The fields now correctly receive the values from node.Identity.ModPath and node.Identity.PkgPath.


zh(optional): 修复了在序列化 AST 节点时 NodeStruct.ModPath 与 NodeStruct.PkgPath 字段可能为空的问题，现已正确从 node.Identity.ModPath 和 node.Identity.PkgPath 取值。




#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
No issue mentioned this.

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
