### PR TITLE
fix: Go parser fails to extract a package-level variable usage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/invopop/jsonschema v0.13.0
 	github.com/mark3labs/mcp-go v0.34.0
+	github.com/pkg/errors v0.9.1
 	github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd
 	github.com/sourcegraph/jsonrpc2 v0.2.0
 	github.com/stretchr/testify v1.10.0
@@ -67,7 +68,6 @@ require (
 	github.com/openai/openai-go v1.10.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/slongfield/pyfmt v0.0.0-20220222012616-ea85ff4c361f // indirect

--- a/lang/golang/parser/file.go
+++ b/lang/golang/parser/file.go
@@ -295,6 +295,26 @@ func (p *GoParser) parseSelector(ctx *fileContext, expr *ast.SelectorExpr, infos
 					return false
 				}
 				return false
+			} else if obj, ok := use.(*types.Var); ok {
+				// collect global var
+				addPkgVarDep := func() {
+					pkg := obj.Pkg()
+					if pkg == nil {
+						return
+					}
+					path := pkg.Path()
+					mod, err := ctx.GetMod(path)
+					if err != nil {
+						return
+					}
+					id := NewIdentity(mod, path, obj.Name())
+					dep := NewDependency(id, ctx.FileLine(ident))
+					infos.globalVars = InsertDependency(infos.globalVars, dep)
+				}
+				// check if it is a global var
+				if isPkgScope(obj.Parent()) {
+					addPkgVarDep()
+				}
 			}
 		}
 	} else if sel, ok := expr.X.(*ast.SelectorExpr); ok {


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.

修复：Go parser 不能完整提取包级别的变量依赖关系

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: We discovered that for an expression like `Object.Call()`, the parser could only extract the dependency on the method `ObjectType.Call()` but failed to capture the dependency on the Object instance itself. This behavior is inconsistent with our LSP-based parsers for other languages, which correctly identify this dependency.

zh: 我们发现，对于 `Object.Call()` 这样的表达式，解析器只能提取出对 `ObjectType.Call()` 方法的依赖，却未能捕获到对 `Object` 实例本身的依赖。该行为与我们基于 LSP 的其他语言解析器不一致。


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

No correlated issue.

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
No correlated documentation.