### PR TITLE
feat: add tool version to UniAST

### DIFF
--- a/lang/parse.go
+++ b/lang/parse.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cloudwego/abcoder/lang/register"
 	"github.com/cloudwego/abcoder/lang/rust"
 	"github.com/cloudwego/abcoder/lang/uniast"
+	"github.com/cloudwego/abcoder/version"
 )
 
 // ParseOptions is the options for parsing the repo.
@@ -104,7 +105,8 @@ func Parse(ctx context.Context, uri string, args ParseOptions) ([]byte, error) {
 		repo.Name = args.RepoID
 	}
 
-	repo.ASTVersion = uniast.Version
+	repo.ASTVersion = uniast.ABCoderSpecificationVersion
+	repo.ABCoderToolVersion = version.ABCoderToolVersion
 
 	out, err := json.Marshal(repo)
 	if err != nil {

--- a/lang/uniast/ast.go
+++ b/lang/uniast/ast.go
@@ -22,6 +22,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/cloudwego/abcoder/version"
 )
 
 type Language string
@@ -83,11 +85,14 @@ type NodeGraph map[string]*Node
 
 // Repository
 type Repository struct {
+	// ASTVersion is 'ABCoder Specification Version'
 	ASTVersion string
-	Name       string             `json:"id"` // module name
-	Path       string             // repo path
-	Modules    map[string]*Module // module name => module
-	Graph      NodeGraph          // node id => node
+	// ABCoderToolVersion is 'ABCoder Tool Version'
+	ABCoderToolVersion string
+	Name               string             `json:"id"` // module name
+	Path               string             // repo path
+	Modules            map[string]*Module // module name => module
+	Graph              NodeGraph          // node id => node
 }
 
 func (r Repository) ID() string {
@@ -107,11 +112,12 @@ func (r Repository) InternalModules() []*Module {
 // NOTICE: Repository.Path is set as name by default, if th name isn't a path, set path somewhere
 func NewRepository(name string) Repository {
 	ret := Repository{
-		Name:       name,
-		Path:       name,
-		Modules:    map[string]*Module{},
-		Graph:      map[string]*Node{},
-		ASTVersion: Version,
+		Name:               name,
+		Path:               name,
+		Modules:            map[string]*Module{},
+		Graph:              map[string]*Node{},
+		ASTVersion:         ABCoderSpecificationVersion,
+		ABCoderToolVersion: version.ABCoderToolVersion,
 	}
 	return ret
 }

--- a/lang/uniast/version.go
+++ b/lang/uniast/version.go
@@ -16,4 +16,4 @@
 
 package uniast
 
-const Version = "v0.1.3"
+const ABCoderSpecificationVersion = "v0.1.3"

--- a/main.go
+++ b/main.go
@@ -47,6 +47,7 @@ import (
 	"github.com/cloudwego/abcoder/llm/agent"
 	"github.com/cloudwego/abcoder/llm/mcp"
 	"github.com/cloudwego/abcoder/llm/tool"
+	"github.com/cloudwego/abcoder/version"
 )
 
 const Usage = `abcoder <Action> [Language] <Path> [Flags]
@@ -106,7 +107,8 @@ func main() {
 
 	switch action {
 	case "version":
-		fmt.Fprintf(os.Stdout, "%s\n", Version)
+		fmt.Fprintf(os.Stdout, "ABCoder Tool Version: %s\n", version.ABCoderToolVersion)
+		fmt.Fprintf(os.Stdout, "ABCoder Universal Abstract-Syntax-Tree Specification Version: %s\n", uniast.ABCoderSpecificationVersion)
 
 	case "parse":
 		language, uri := parseArgsAndFlags(flags, true, flagHelp, flagVerbose)
@@ -183,7 +185,7 @@ func main() {
 
 		svr := mcp.NewServer(mcp.ServerOptions{
 			ServerName:    "abcoder",
-			ServerVersion: Version,
+			ServerVersion: version.ABCoderToolVersion,
 			Verbose:       *flagVerbose,
 			ASTReadToolsOptions: tool.ASTReadToolsOptions{
 				RepoASTsDir: uri,

--- a/version/version.go
+++ b/version/version.go
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-package main
+package version
 
 const (
-	Version = "0.2.1"
+	ABCoderToolVersion = "0.2.1"
 )


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
