### PR TITLE
fix(lang/go): when it's method, exported is determined by the Method name but …

### DIFF
--- a/lang/golang/parser/file.go
+++ b/lang/golang/parser/file.go
@@ -225,7 +225,14 @@ func (p *GoParser) parseVar(ctx *fileContext, vspec *ast.ValueSpec, isConst bool
 
 // newFunc allocate a function in the repo
 func (p *GoParser) newFunc(mod, pkg, name string) *Function {
-	ret := &Function{Identity: NewIdentity(mod, pkg, name), Exported: isUpperCase(name[0])}
+	var exported bool
+	if ind := strings.LastIndexByte(name, '.'); ind != -1 && ind+1 < len(name) {
+		exported = isUpperCase(name[ind+1])
+	} else {
+		exported = isUpperCase(name[0])
+	}
+
+	ret := &Function{Identity: NewIdentity(mod, pkg, name), Exported: exported}
 	return p.repo.SetFunction(ret.Identity, ret)
 }
 


### PR DESCRIPTION
…not its receiver

#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
当是类的方法时，是否导出应该由方法的实际名字确定，而不是类的名字。

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 
因为当这里是类的方法时，name 是 `{struct name}.{method name}`，当然也可能是多层组合的 `{struct name}.{struct name}.{method name}`，所以要根据 `{method name}` 的首字母来判断。

比如 `struct a {}` 有一个方法 `func (*a) Do()` 实际上这个 `Do` 方法是导出的；
当 `struct A {}` 有一个方法 `func (*A) do()` 实际上这个方法是非导出的。

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
