### PR TITLE
fix: getFileStruct null pointer exception

### DIFF
--- a/llm/tool/ast_read.go
+++ b/llm/tool/ast_read.go
@@ -398,7 +398,9 @@ func (t *ASTReadTools) GetFileStructure(_ context.Context, req GetFileStructReq)
 	log.Debug("get file structure, req: %v", abutil.MarshalJSONIndentNoError(req))
 	resp, err := t.getFileStructure(context.Background(), req, true)
 	if err != nil {
-		resp.Error = err.Error()
+		return &GetFileStructResp{
+			Error: err.Error(),
+		}, nil
 	}
 	log.Debug("get repo structure, resp: %v", abutil.MarshalJSONIndentNoError(resp))
 	return resp, nil


### PR DESCRIPTION
When I enter a FilePath that does not meet the specified rules, resp will be a null pointer error.