### PR TITLE
fix(go): continue parsing chained selector method calls

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -82,13 +82,14 @@ jobs:
         run: |
           # HACK: auto installation uses the published version, not our local version
           (cd ./main_repo/ts-parser && npm install && npm run build && npm install -g .)
-          OUTDIR=out_old ABCEXE=./abcoder_old ./main_repo/script/run_testdata.sh first
+          OUTDIR=out_old ABCEXE=./abcoder_old ./pr_repo/script/run_testdata.sh first
           # avoid wasting time install a new jdtls
           echo "JDTLS_ROOT_PATH=$(realpath ./main_repo/lang/java/lsp/jdtls/jdt-language-server-*)" >> $GITHUB_ENV
 
       - name: Run OLD abcoder
         run:
-          OUTDIR=out_old ABCEXE=./abcoder_old ./main_repo/script/run_testdata.sh all
+          # we run the old abcoder on the new data to compare the outputs
+          OUTDIR=out_old ABCEXE=./abcoder_old ./pr_repo/script/run_testdata.sh all
 
       - name: Reset dependencies
         run: |

--- a/lang/golang/parser/file.go
+++ b/lang/golang/parser/file.go
@@ -354,21 +354,6 @@ func (p *GoParser) parseSelector(ctx *fileContext, expr *ast.SelectorExpr, infos
 	} else if sel, ok := expr.X.(*ast.SelectorExpr); ok {
 		// recurse call
 		cont = p.parseSelector(ctx, sel, infos)
-	} else {
-		// try to get type info of field first
-		if ti := ctx.GetTypeInfo(expr); ti.Ty != nil {
-			if _, ok := ti.Ty.(*types.Signature); ok {
-				// collect method call
-				// method call
-				rev := ctx.GetTypeInfo(expr.X)
-				if !rev.IsStdOrBuiltin {
-					id := NewIdentity(rev.Id.ModPath, rev.Id.PkgPath, rev.Id.Name+"."+expr.Sel.Name)
-					dep := NewDependency(id, ctx.FileLine(expr.Sel))
-					infos.methodCalls = InsertDependency(infos.methodCalls, dep)
-				}
-			}
-		}
-		return true
 	}
 
 	// method calls
@@ -400,7 +385,9 @@ func (p *GoParser) parseSelector(ctx *fileContext, expr *ast.SelectorExpr, infos
 			}
 			infos.methodCalls = InsertDependency(infos.methodCalls, dep)
 		}
-		return false
+
+		// 此处应该是 true，用于处理 chained method call，让 visit 可以继续处理
+		return true
 	}
 
 	return cont

--- a/lang/lsp/clients_test.go
+++ b/lang/lsp/clients_test.go
@@ -63,7 +63,9 @@ func TestGolangLSP(t *testing.T) {
 
 	uri := NewURI(goTestCase + "/pkg/entity/entity.go")
 	// documentSymbol
-	expectedSymNames := `(MyStruct).String
+	expectedSymNames := `(*MyStruct).Return0
+(*MyStruct).Return4
+(MyStruct).String
 (MyStructC).String
 (MyStructD).DFunction
 (MyStructD).String

--- a/testdata/go/0_golang/pkg/entity/entity.go
+++ b/testdata/go/0_golang/pkg/entity/entity.go
@@ -61,3 +61,11 @@ const G1 = 1
 type Integer int
 
 var V1 = Integer(1)
+
+func (a *MyStruct) Return0() *MyStruct {
+	return a
+}
+
+func (a *MyStruct) Return4() string {
+	return a.Return0().DFunction()
+}


### PR DESCRIPTION
Allow selector traversal to keep visiting chained method calls instead of returning early, so downstream calls can still be collected during Go parsing.

#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix
#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
修复：golang 链式调用中，无法正确解析 Function Recv 的问题

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 

在下面这样的代码中
```go
type A struct {}
type E struct { A }

func (a *A) AFunction() {}

func (e *E) Return() *E {
    return e
}

func (e *E)  Raw() {
    e.Return().AFunction()
}
```
AFunction 的 NodeID Name 会被解析成 `E.AFunction` 而不是 `A.AFunction`

测试中， `Return4` 的 `MethodCalls` 中 `DFunction` 应该是：
```json
                {
                  "ModPath": "a.b/c",
                  "PkgPath": "a.b/c/pkg/entity",
                  "Name": "MyStructD.DFunction",
                  "File": "pkg/entity/entity.go",
                  "Line": 78,
                  "StartOffset": 1458,
                  "EndOffset": 1465,
                  "Extra": {
                    "IsInvoked": true
                  }
                }
``` 
原来的代码中，会返回：
```json
                {
                  "ModPath": "a.b/c",
                  "PkgPath": "a.b/c/pkg/entity",
                  "Name": "MyStruct.DFunction",
                  "File": "pkg/entity/entity.go",
                  "Line": 78,
                  "StartOffset": 1458,
                  "EndOffset": 1465,
                  "Extra": {
                    "IsInvoked": true
                  }
                }
``` 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
