### PR TITLE
fix(golang): skip out-of-repo local replace targets to avoid nil panic

### DIFF
--- a/lang/golang/parser/parser.go
+++ b/lang/golang/parser/parser.go
@@ -148,7 +148,7 @@ func (p *GoParser) collectGoMods(startDir string) error {
 		p.repo.Modules[name] = newModule(name, rel)
 		p.modules = append(p.modules, newModuleInfo(name, rel, name))
 
-		deps, cgoPkgs, err = getDeps(filepath.Dir(path), p.workDirs)
+		deps, cgoPkgs, err = getDeps(filepath.Dir(path), p.homePageDir, p.workDirs)
 		if err != nil {
 			return err
 		}
@@ -192,7 +192,7 @@ type dep struct {
 	CgoFiles []string `json:"CgoFiles"`
 }
 
-func getDeps(dir string, workDirs map[string]bool) (a map[string]string, cgoPkgs map[string]bool, err error) {
+func getDeps(dir string, homePageDir string, workDirs map[string]bool) (a map[string]string, cgoPkgs map[string]bool, err error) {
 	cgoPkgs = make(map[string]bool)
 	absDir, err := filepath.Abs(dir)
 	if err != nil {
@@ -268,9 +268,20 @@ func getDeps(dir string, workDirs map[string]bool) (a map[string]string, cgoPkgs
 			if strings.HasPrefix(module.Replace.Path, "./") ||
 				strings.HasPrefix(module.Replace.Path, "../") ||
 				strings.HasPrefix(module.Replace.Path, "/") {
-				// local replace
-				deps[module.Path] = module.Path
+				// local replace: only treat as a parseable module when the
+				// target lives inside the repo root. Out-of-repo replace
+				// targets cannot be walked by collectGoMods, so skip them
+				// here to avoid downstream nil-module lookups.
+				replaceAbs := module.Replace.Path
+				if !filepath.IsAbs(replaceAbs) {
+					replaceAbs = filepath.Join(dir, replaceAbs)
+				}
+				replaceAbs = filepath.Clean(replaceAbs)
 
+				rel, relErr := filepath.Rel(homePageDir, replaceAbs)
+				if relErr == nil && !strings.HasPrefix(rel, "..") {
+					deps[module.Path] = module.Path
+				}
 			} else {
 				deps[module.Path] = module.Replace.Path + "@" + module.Replace.Version
 			}
@@ -294,10 +305,12 @@ func getDeps(dir string, workDirs map[string]bool) (a map[string]string, cgoPkgs
 // ParseRepo parse the entiry repo from homePageDir recursively until end
 func (p *GoParser) ParseRepo() (Repository, error) {
 	for _, lib := range p.modules {
-		if strings.Contains(lib.path, "@") {
+		mod := p.repo.Modules[lib.name]
+		if mod == nil {
+			// Not a module of this repo (external dep, or out-of-repo
+			// local replace target). Skip parsing.
 			continue
 		}
-		mod := p.repo.Modules[lib.name]
 		if err := p.ParseModule(mod, filepath.Join(p.homePageDir, mod.Dir)); err != nil {
 			return p.getRepo(), err
 		}

--- a/lang/golang/parser/parser.go
+++ b/lang/golang/parser/parser.go
@@ -305,10 +305,13 @@ func getDeps(dir string, homePageDir string, workDirs map[string]bool) (a map[st
 // ParseRepo parse the entiry repo from homePageDir recursively until end
 func (p *GoParser) ParseRepo() (Repository, error) {
 	for _, lib := range p.modules {
+		if strings.Contains(lib.path, "@") {
+			continue
+		}
 		mod := p.repo.Modules[lib.name]
 		if mod == nil {
-			// Not a module of this repo (external dep, or out-of-repo
-			// local replace target). Skip parsing.
+			// Out-of-repo local replace target — collectGoMods didn't
+			// register it; skip to avoid nil deref.
 			continue
 		}
 		if err := p.ParseModule(mod, filepath.Join(p.homePageDir, mod.Dir)); err != nil {


### PR DESCRIPTION
Local `replace => /abs` or `replace => ../outside` targets are not walked by collectGoMods, so they are absent from p.repo.Modules. ParseRepo's old `@`-based skip didn't filter them, causing a nil deref on mod.Dir.

Switch ParseRepo's skip to the canonical signal (mod == nil) and have getDeps only record local replace deps whose target lives inside the repo root.

#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
修复当存在 Replace 到外部时，ABCoder panic 的问题

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
