### PR TITLE
fix(java): simplify NodeID name to methodName(paramTypes)

### DIFF
--- a/lang/collect/collect.go
+++ b/lang/collect/collect.go
@@ -2530,7 +2530,13 @@ func buildJavaMethodID(m *javapb.MethodDetail) string {
 	if m == nil {
 		return ""
 	}
-	name := m.GetName()
+	name := strings.TrimSpace(m.GetName())
+	// GetName() may still contain modifiers + return type when the JAR's
+	// Descriptor uses the long form (e.g. "abstract void foo"). Take the last
+	// token after any space.
+	if sp := strings.LastIndexByte(name, ' '); sp >= 0 {
+		name = name[sp+1:]
+	}
 	if name == "" {
 		return ""
 	}
@@ -2547,6 +2553,9 @@ func buildJavaMethodID(m *javapb.MethodDetail) string {
 			continue
 		}
 		types = append(types, t)
+	}
+	if len(types) == 0 {
+		return name
 	}
 	return name + "(" + strings.Join(types, ",") + ")"
 }

--- a/lang/collect/collect.go
+++ b/lang/collect/collect.go
@@ -830,10 +830,7 @@ func (c *Collector) ScannerByJavaIPC(ctx context.Context) ([]*DocumentSymbol, er
 			if m == nil {
 				continue
 			}
-			name := m.Descriptor
-			if name == "" {
-				name = m.GetName()
-			}
+			name := buildJavaMethodID(m)
 			if name == "" {
 				continue
 			}
@@ -2522,6 +2519,36 @@ func (c *Collector) extractRootIdentifier(node *sitter.Node, content []byte) str
 	}
 
 	return ""
+}
+
+// buildJavaMethodID generates the simplified NodeID.Name for a Java method:
+//   methodName(ParamRawType1,ParamRawType2,...)
+// Strips access modifiers, static/final/etc., annotations, return type, throws,
+// and parameter names. Prefers ParameterDetail.TypeRawText (preserves generics
+// and array notation as written) and falls back to TypeFqcn.
+func buildJavaMethodID(m *javapb.MethodDetail) string {
+	if m == nil {
+		return ""
+	}
+	name := m.GetName()
+	if name == "" {
+		return ""
+	}
+	types := make([]string, 0, len(m.Parameters))
+	for _, p := range m.Parameters {
+		if p == nil {
+			continue
+		}
+		t := p.TypeRawText
+		if t == "" {
+			t = p.TypeFqcn
+		}
+		if t == "" {
+			continue
+		}
+		types = append(types, t)
+	}
+	return name + "(" + strings.Join(types, ",") + ")"
 }
 
 // parseMethodSignature 从方法节点解析签名，保留方法名和参数类型


### PR DESCRIPTION
Java method NodeIDs were using the JAR-provided Descriptor/RawText directly, which often included modifiers, return type, throws clause, parameter names and annotations. Rebuild the name from MethodDetail's parameter list (TypeRawText, falling back to TypeFqcn) so NodeIDs are stable and concise — e.g. queryJwtToken(String,String,String).

#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 
优化前：
```text
AbsPowerOpsController.public void downloadPowerOps(HttpServletResponse response, @RequestParam @ApiParam(value = "工单ID", required = true) String xflowId)
```
优化后：
```test
AbsPowerOpsController.downloadPowerOps(HttpServletResponse,String)
```


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
