### PR TITLE
fix(java): make Type.Methods Identity.Name and Graph relations deterministic

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     #if: "!contains(github.event.pull_request.title, '[NO-REGRESSION-TEST]')"
     env:
-      LANGS: "go rust python typescript cxx cpp"
+      LANGS: "go rust python typescript cxx cpp java"
       # ignore package version for Go e.g. 'a.b/c@506fb8ece467f3a71c29322169bef9b0bc92d554'
       DIFFJSON_IGNORE: >
         ['id']
@@ -82,14 +82,16 @@ jobs:
         run: |
           # HACK: auto installation uses the published version, not our local version
           (cd ./main_repo/ts-parser && npm install && npm run build && npm install -g .)
-          OUTDIR=out_old ABCEXE=./abcoder_old ./pr_repo/script/run_testdata.sh first
+          JAVA_PARSER_JAR_PATH=$(realpath ./main_repo/lang/java/ipc/abcoder-java-analyzer-1.0-SNAPSHOT.jar) \
+            OUTDIR=out_old ABCEXE=./abcoder_old ./pr_repo/script/run_testdata.sh first
           # avoid wasting time install a new jdtls
           echo "JDTLS_ROOT_PATH=$(realpath ./main_repo/lang/java/lsp/jdtls/jdt-language-server-*)" >> $GITHUB_ENV
 
       - name: Run OLD abcoder
-        run:
+        run: |
           # we run the old abcoder on the new data to compare the outputs
-          OUTDIR=out_old ABCEXE=./abcoder_old ./pr_repo/script/run_testdata.sh all
+          JAVA_PARSER_JAR_PATH=$(realpath ./main_repo/lang/java/ipc/abcoder-java-analyzer-1.0-SNAPSHOT.jar) \
+            OUTDIR=out_old ABCEXE=./abcoder_old ./pr_repo/script/run_testdata.sh all
 
       - name: Reset dependencies
         run: |
@@ -98,11 +100,13 @@ jobs:
       - name: Install dependencies for new
         run: |
           (cd ./pr_repo/ts-parser && npm install && npm run build && npm install -g .)
-          OUTDIR=out_new ABCEXE=./abcoder_new ./pr_repo/script/run_testdata.sh first
+          JAVA_PARSER_JAR_PATH=$(realpath ./pr_repo/lang/java/ipc/abcoder-java-analyzer-1.0-SNAPSHOT.jar) \
+            OUTDIR=out_new ABCEXE=./abcoder_new ./pr_repo/script/run_testdata.sh first
 
       - name: Run NEW abcoder
-        run:
-          OUTDIR=out_new ABCEXE=./abcoder_new ./pr_repo/script/run_testdata.sh all
+        run: |
+          JAVA_PARSER_JAR_PATH=$(realpath ./pr_repo/lang/java/ipc/abcoder-java-analyzer-1.0-SNAPSHOT.jar) \
+            OUTDIR=out_new ABCEXE=./abcoder_new ./pr_repo/script/run_testdata.sh all
 
       - name: Upload output directories
         uses: actions/upload-artifact@v4

--- a/lang/collect/export.go
+++ b/lang/collect/export.go
@@ -354,6 +354,27 @@ func (c *Collector) exportSymbol(repo *uniast.Repository, symbol *DocumentSymbol
 
 	tmp := uniast.NewIdentity(mod, path, name)
 	id = &tmp
+
+	// Eagerly prefix Identity.Name for methods so a cyclic visit
+	// (receiver Type -> receivers map -> back to this method via the
+	// visited cache) reads the final name, not the bare one. Without
+	// this, Type.Methods[k] = *mid value-copies a partially-built id
+	// non-deterministically. Cpp finalizes name in the SKMethod branch
+	// because it needs extractCppCallSig + namespace munging.
+	if c.Language != uniast.Cpp && (symbol.Kind == SKMethod || symbol.Kind == SKFunction) {
+		if mi := c.funcs[symbol].Method; mi != nil && mi.Receiver.Symbol != nil {
+			recvName := mi.Receiver.Symbol.Name
+			if mi.Interface != nil && mi.Interface.Symbol != nil {
+				recvName = mi.Interface.Symbol.Name + "<" + recvName + ">"
+			}
+			sep := "."
+			if symbol.Kind == SKFunction {
+				sep = "::"
+			}
+			id.Name = recvName + sep + name
+		}
+	}
+
 	// Save to visited ONLY WHEN no errors occur
 	visited[symbol] = id
 

--- a/lang/uniast/ast_test.go
+++ b/lang/uniast/ast_test.go
@@ -43,6 +43,36 @@ func TestRepository_BuildGraph(t *testing.T) {
 	}
 }
 
+// TestRepository_BuildGraph_Deterministic ensures BuildGraph yields a byte-stable
+// JSON repeatedly. Relation slices (References, Dependencies, etc.) are filled
+// via map iteration, so without an explicit canonical sort each run produced a
+// different order and downstream diffs lit up spurious changes.
+func TestRepository_BuildGraph_Deterministic(t *testing.T) {
+	astFile := testutils.GetTestAstFile("localsession")
+
+	var prev []byte
+	for i := 0; i < 5; i++ {
+		r, err := LoadRepo(astFile)
+		if err != nil {
+			t.Fatalf("iter %d: load repo: %v", i, err)
+		}
+		if err := r.BuildGraph(); err != nil {
+			t.Fatalf("iter %d: build graph: %v", i, err)
+		}
+		js, err := json.Marshal(r)
+		if err != nil {
+			t.Fatalf("iter %d: marshal: %v", i, err)
+		}
+		if i == 0 {
+			prev = js
+			continue
+		}
+		if string(prev) != string(js) {
+			t.Fatalf("iter %d: BuildGraph output is not byte-stable across runs (len %d vs %d)", i, len(prev), len(js))
+		}
+	}
+}
+
 func BenchmarkRepository_BuildGraph(b *testing.B) {
 	astFile := testutils.GetTestAstFile("large_ast")
 	r, err := LoadRepo(astFile)

--- a/lang/uniast/node.go
+++ b/lang/uniast/node.go
@@ -15,6 +15,7 @@
 package uniast
 
 import (
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -256,6 +257,31 @@ func (r *Repository) BuildGraph() error {
 				}
 			}
 		}
+	}
+
+	// Canonicalize relation slice order. AddRelation is fed from map
+	// iterations, so insertion order varies between runs.
+	sortRelations := func(rs []Relation) {
+		if len(rs) < 2 {
+			return
+		}
+		sort.Slice(rs, func(i, j int) bool {
+			a, b := rs[i].Identity.Full(), rs[j].Identity.Full()
+			if a != b {
+				return a < b
+			}
+			if rs[i].Line != rs[j].Line {
+				return rs[i].Line < rs[j].Line
+			}
+			return rs[i].Kind < rs[j].Kind
+		})
+	}
+	for _, node := range r.Graph {
+		sortRelations(node.Dependencies)
+		sortRelations(node.References)
+		sortRelations(node.Implements)
+		sortRelations(node.Inherits)
+		sortRelations(node.Groups)
 	}
 	return nil
 }


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix
#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
Two sources of non-determinism in Java IPC parsing surfaced as method-name flapping in `Type.Methods[k].Name` and reordered `Graph.*.References` between runs:

1. exportSymbol stored the new *Identity in `visited` with the bare method name and only updated `id.Name` to the prefixed form (`Receiver.method` or `Receiver::method`) after recursing into the receiver. The receiver's SKStruct branch iterates its `receivers[R]` map and value-copies `*mid` into `Type.Methods[k]`; if that recursion landed on the very method that started the chain, it captured the still-bare name. Which method flapped per Type depended on Go map iteration order. Fix: pre-compute the prefixed Identity.Name for SKMethod/SKFunction in non-Cpp languages before inserting into `visited`, so cyclic visits read the final name.

2. BuildGraph fills `Node.References/Dependencies/Implements/Inherits/ Groups` while iterating `pkg.Functions/Types/Vars` maps, so insertion order varied. Sort those slices by (Identity.Full(), Line, Kind) at the end of BuildGraph to make JSON byte-stable.

zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
