### PR TITLE
fix(java): set IsInterfaceMethod for interface methods

### DIFF
--- a/lang/collect/export.go
+++ b/lang/collect/export.go
@@ -417,18 +417,31 @@ func (c *Collector) exportSymbol(repo *uniast.Repository, symbol *DocumentSymbol
 	switch k := symbol.Kind; k {
 	// Function
 	case SKFunction, SKMethod:
+		info := c.funcs[symbol]
+		// Detect interface-method via LSP parent first (cli.files populated).
+		// Java IPC mode does not populate cli.files, so fall back to the
+		// receiver symbol kind recorded by the scanner.
+		isInterfaceMethod := false
 		if c.cli != nil {
 			if p := c.cli.GetParent(symbol); p != nil && p.Kind == SKInterface {
-				// NOTICE: no need collect interface method
-				break
+				isInterfaceMethod = true
 			}
 		}
-		obj := &uniast.Function{
-			FileLine: fileLine,
-			Content:  content,
-			Exported: public,
+		if isInterfaceMethod {
+			// NOTICE: no need collect interface method for non-Java langs.
+			// Java still collects it but flags IsInterfaceMethod.
+			break
 		}
-		info := c.funcs[symbol]
+		if info.Method != nil && info.Method.Receiver.Symbol != nil &&
+			info.Method.Receiver.Symbol.Kind == SKInterface {
+			isInterfaceMethod = true
+		}
+		obj := &uniast.Function{
+			FileLine:          fileLine,
+			Content:           content,
+			Exported:          public,
+			IsInterfaceMethod: isInterfaceMethod,
+		}
 		obj.Signature = info.Signature
 		// NOTICE: type parames collect into types
 		if info.TypeParams != nil {


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix
#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
In Java IPC mode `cli.files` is never populated, so the existing `GetParent` check in export.go could not detect interface parents and every interface method was emitted with `IsInterfaceMethod=false`.

Fall back to the receiver symbol's Kind (set to SKInterface by the IPC scanner via `classKind(ci)`) when the LSP-based check yields nil. Non-Java paths keep their original behaviour: when GetParent succeeds and reports an interface parent, the method is still skipped.

zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
