### PR TITLE
fix(go): fill File-level metadata for pre-parsed packages

### DIFF
--- a/lang/golang/parser/pkg.go
+++ b/lang/golang/parser/pkg.go
@@ -217,11 +217,18 @@ func (p *GoParser) loadPackages(mod *Module, dir string, pkgPath PkgPath) (err e
 	fmt.Fprintf(os.Stderr, "[loadPackages] mod: %s, dir: %s, pkgPath: %s, hasCGO: %v\n", mod.Name, dir, pkgPath, hasCGO)
 
 	for _, pkg := range pkgs {
+		// The package may have been pre-parsed by referCodes for cross-module
+		// references (only Functions populated, no File-level Package/Imports).
+		// We must not skip entirely: otherwise File.Package and File.Imports
+		// remain empty, breaking downstream reachability analysis based on
+		// the package import graph. Instead, still fill File-level metadata
+		// but skip duplicate function body parsing and package-level finalization.
+		alreadyParsed := false
 		if mm := p.repo.Modules[mod.Name]; mm != nil && (*mm).Packages[pkg.ID] != nil {
-			continue
+			alreadyParsed = true
 		}
 		if pp, ok := mod.Packages[pkg.ID]; ok && pp != nil {
-			continue
+			alreadyParsed = true
 		}
 		for idx, file := range pkg.Syntax {
 			var filePath string
@@ -278,9 +285,16 @@ func (p *GoParser) loadPackages(mod *Module, dir string, pkgPath PkgPath) (err e
 				f.Package = pkg.ID
 				f.Imports = imports.Origins
 			}
+			// Skip duplicate function body parsing when package was pre-parsed.
+			if alreadyParsed {
+				continue
+			}
 			if err := p.parseFile(ctx, file); err != nil {
 				return err
 			}
+		}
+		if alreadyParsed {
+			continue
 		}
 		if obj := mod.Packages[pkg.ID]; obj != nil {
 			// obj.Dependencies = make([]PkgPath, 0, len(pkg.Imports))


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix
#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
When a package was pre-parsed via cross-module referCodes, only Functions were populated but File.Package/Imports were left empty. This broke downstream reachability analysis based on the package import graph. Now we still fill File-level metadata for such packages while skipping duplicate function-body parsing.

zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
