### PR TITLE
fix(cpp): survive clangd crashes and degenerate ranges during parse

### DIFF
--- a/lang/collect/collect.go
+++ b/lang/collect/collect.go
@@ -120,6 +120,10 @@ type Collector struct {
 	// doesn't implement textDocument/ast (jsonrpc2 -32601). After this
 	// we stop issuing AST requests entirely.
 	cppASTUnsupported bool
+	// cppTHCrashes counts typeHierarchy-attributed clangd crashes (for
+	// visibility only — typeHierarchy is NOT disabled; the server is
+	// restarted and typeHierarchy keeps being used). Guarded by c.mu.
+	cppTHCrashes int
 	// exportCtx is the context.Context belonging to the current Export()
 	// invocation. Set at the top of Export and cleared at return; gives
 	// exportSymbol-and-friends access to ctx without rippling a new
@@ -198,9 +202,27 @@ func (c *Collector) cppASTForSymbol(ctx context.Context, sym *DocumentSymbol) *A
 	if c.cli == nil || sym == nil || c.cppASTUnsupported {
 		return nil
 	}
+	// clangd's textDocument/ast returns the tightest AST node that fully
+	// CONTAINS the requested range, but it deliberately returns null when
+	// that node is the TranslationUnitDecl — it refuses to dump a whole TU
+	// (which would expand every system/3rd-party include). A whole-file
+	// range therefore only resolves for files whose entire content sits
+	// under a single top-level node (typical headers: one `namespace {...}`).
+	// A .cpp/.cc with multiple top-level decls (includes + several out-of-
+	// line definitions + DEFINE_* macros) always resolves to the TU, so its
+	// whole-file request is null — verified empirically: even a single-line
+	// range at the top of such a file returns null, while a range enclosed
+	// by one method definition returns that CXXMethod node. The whole-file
+	// result is cached, so retry the (one-RPC, header-friendly) path first;
+	// when it's nil, fall back to a per-symbol request scoped to the
+	// symbol's own range, which clangd answers reliably for out-of-line
+	// .cpp definitions.
 	root := c.cppFileAST(ctx, sym.Location.URI)
 	if root == nil {
-		return nil
+		root = c.cppSymbolAST(ctx, sym)
+		if root == nil {
+			return nil
+		}
 	}
 	target := sym.Location.Range
 	var best *ASTNode
@@ -222,11 +244,62 @@ func (c *Collector) cppASTForSymbol(ctx context.Context, sym *DocumentSymbol) *A
 	if best != nil {
 		return best
 	}
+	// Fallback: LSP documentSymbol ranges and clangd AST node ranges often
+	// disagree on the END boundary for multi-line out-of-line definitions
+	// (e.g. `int C::f(...) { ... }` in a .cpp): documentSymbol reports the
+	// closing-brace line, clangd's AST FunctionDecl range can end a line
+	// earlier, so the strict full-range Include above misses the node and
+	// hasBody wrongly defaults to false — losing the .cpp body at dedup.
+	// The symbol's START position is reliable, so retry matching only that,
+	// picking the smallest enclosing declaration node.
+	startOnly := Range{Start: target.Start, End: target.Start}
+	var walkStart func(n *ASTNode)
+	walkStart = func(n *ASTNode) {
+		if n == nil {
+			return
+		}
+		if n.Role == ASTRoleDeclaration && n.Range.Include(startOnly) {
+			if best == nil || best.Range.Include(n.Range) {
+				best = n
+			}
+		}
+		for _, ch := range n.Children {
+			walkStart(ch)
+		}
+	}
+	walkStart(root)
+	if best != nil {
+		return best
+	}
 	// No declaration node matched the symbol's range — return nil rather
 	// than falling back to the TranslationUnit root, which would let
 	// downstream callers (e.g. cppASTHasBody) confuse "no symbol here"
 	// with "found some unrelated node".
 	return nil
+}
+
+// cppSymbolAST fetches the AST scoped to a single symbol's range. The
+// whole-file AST is unusable for .cpp files (clangd returns null for any
+// range whose tightest enclosing node is the TranslationUnitDecl), so this
+// per-symbol request is the primary path for out-of-line definitions: the
+// symbol's range is enclosed by its own FunctionDecl/CXXMethodDecl, which
+// clangd returns reliably — including the Compound body child used by
+// HasFunctionBody to tell a definition from a declaration.
+func (c *Collector) cppSymbolAST(ctx context.Context, sym *DocumentSymbol) *ASTNode {
+	if c.cppASTUnsupported {
+		return nil
+	}
+	_, _ = c.cli.DidOpen(ctx, sym.Location.URI)
+	node, err := c.cli.AST(ctx, sym.Location.URI, sym.Location.Range)
+	if err != nil {
+		if IsJSONRPCMethodNotFound(err) {
+			c.mu.Lock()
+			c.cppASTUnsupported = true
+			c.mu.Unlock()
+		}
+		return nil
+	}
+	return node
 }
 
 // cppFileAST returns the cached AST root for uri, fetching once on
@@ -322,6 +395,23 @@ func (c *Collector) cppASTKind(ctx context.Context, sym *DocumentSymbol) (kind s
 // class extend" — clangd has the parsed C++ AST so it knows about
 // using-declarations, type aliases, and namespace-qualified bases
 // without us reparsing the declaration text.
+// noteTHError records a typeHierarchy RPC failure. Connection-loss failures
+// are the clangd crash signature; we count + log them for visibility but do
+// NOT disable typeHierarchy. The LSPClient respawns the server and the next
+// class is attempted again — typeHierarchy stays enabled for the whole parse.
+// The crashing class still gets its bases via collectCppBasesViaAST (always
+// called alongside), so nothing is lost by keeping typeHierarchy on.
+func (c *Collector) noteTHError(err error) {
+	if err == nil || !IsConnClosed(err) {
+		return
+	}
+	c.mu.Lock()
+	c.cppTHCrashes++
+	n := c.cppTHCrashes
+	c.mu.Unlock()
+	log.Error("C++ typeHierarchy crashed the LSP server (count=%d); restarted, continuing with typeHierarchy still enabled", n)
+}
+
 func (c *Collector) collectCppBasesViaTypeHierarchy(ctx context.Context, sym *DocumentSymbol) bool {
 	if c.cli == nil {
 		return false
@@ -333,13 +423,18 @@ func (c *Collector) collectCppBasesViaTypeHierarchy(ctx context.Context, sym *Do
 		pos = sym.SelectionRange.Start
 	}
 	items, err := c.cli.PrepareTypeHierarchy(ctx, sym.Location.URI, pos)
-	if err != nil || len(items) == 0 {
+	if err != nil {
+		c.noteTHError(err)
+		return false
+	}
+	if len(items) == 0 {
 		return false
 	}
 	resolvedAny := false
 	for _, item := range items {
 		supers, err := c.cli.TypeHierarchySupertypes(ctx, item)
 		if err != nil {
+			c.noteTHError(err)
 			continue
 		}
 		for _, sup := range supers {
@@ -354,6 +449,97 @@ func (c *Collector) collectCppBasesViaTypeHierarchy(ctx context.Context, sym *Do
 		}
 	}
 	return resolvedAny
+}
+
+// collectCppBasesViaAST resolves base classes from clangd's
+// textDocument/ast. Unlike typeHierarchy/supertypes, the AST exposes
+// base specifiers for DEPENDENT TEMPLATE bases too
+// (`class Foo : public Tmpl<X,Y>`): the class's CXXRecord node carries a
+// child with role=="base" whose nested type node (TemplateSpecialization
+// for templated bases, Record otherwise) points at the base class name in
+// source. We resolve that position via textDocument/definition
+// (getSymbolByToken) and record an implements-rel. Pure LSP — no text
+// parsing of the inheritance clause.
+func (c *Collector) collectCppBasesViaAST(ctx context.Context, sym *DocumentSymbol) {
+	if c.cli == nil {
+		return
+	}
+	// Reuse the cached whole-file AST (cppASTForSymbol → cppFileAST cache):
+	// one textDocument/ast per FILE, not per class. The returned node is the
+	// tightest declaration containing the class range — i.e. its CXXRecord,
+	// whose children carry the base specifiers.
+	rec := c.cppASTForSymbol(ctx, sym)
+	if rec == nil {
+		return
+	}
+	if rec.Kind != "CXXRecord" {
+		if r := cppFindRecord(rec, sym.Name); r != nil {
+			rec = r
+		}
+	}
+	for _, child := range rec.Children {
+		if child.Role != "base" {
+			continue
+		}
+		pos, ok := cppBaseNamePos(child)
+		if !ok {
+			continue
+		}
+		loc := Location{URI: sym.Location.URI, Range: Range{Start: pos, End: pos}}
+		baseSym, err := c.getSymbolByToken(ctx, Token{Location: loc, Type: "class"})
+		if err != nil || baseSym == nil || baseSym == sym || baseSym.Name == "" {
+			continue
+		}
+		c.addImplementsRel(sym, baseSym, loc)
+	}
+}
+
+// cppFindRecord returns the CXXRecord declaration node for class `name`
+// within an AST subtree (the cli.AST root may be the record itself or a
+// wrapping node). Returns nil if not found.
+func cppFindRecord(n *ASTNode, name string) *ASTNode {
+	if n == nil {
+		return nil
+	}
+	if n.Role == ASTRoleDeclaration && n.Kind == "CXXRecord" && (name == "" || n.Detail == name) {
+		return n
+	}
+	for _, ch := range n.Children {
+		if r := cppFindRecord(ch, name); r != nil {
+			return r
+		}
+	}
+	return nil
+}
+
+// cppBaseNamePos finds the source position of the base class NAME under a
+// role=="base" specifier node. It returns the start of the outermost
+// (pre-order first) type node of kind TemplateSpecialization or Record —
+// i.e. the base class itself, not its template arguments or enclosing
+// namespace specifiers.
+func cppBaseNamePos(base *ASTNode) (Position, bool) {
+	var found *ASTNode
+	var walk func(n *ASTNode) bool
+	walk = func(n *ASTNode) bool {
+		if n == nil {
+			return false
+		}
+		if n.Role == "type" && (n.Kind == "TemplateSpecialization" || n.Kind == "Record") {
+			found = n
+			return true
+		}
+		for _, ch := range n.Children {
+			if walk(ch) {
+				return true
+			}
+		}
+		return false
+	}
+	walk(base)
+	if found == nil {
+		return Position{}, false
+	}
+	return found.Range.Start, true
 }
 
 type methodInfo struct {
@@ -446,6 +632,20 @@ func (c *Collector) configureLSP(ctx context.Context) {
 	}
 }
 
+// runSafe runs fn, recovering from any panic so a single bad symbol — e.g. a
+// clangd-reported degenerate token range that trips an out-of-range slice in
+// the language spec (CppSpec.FunctionSymbol) — is skipped instead of killing
+// the whole parse. This is the in-process half of "crash → skip & continue";
+// the LSPClient restart logic handles the other half (server crashes).
+func (c *Collector) runSafe(what string, fn func()) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error("recovered from panic during %s (skipping symbol): %v", what, r)
+		}
+	}()
+	fn()
+}
+
 func (c *Collector) Collect(ctx context.Context) error {
 	var root_syms []*DocumentSymbol
 	var err error
@@ -479,7 +679,7 @@ func (c *Collector) Collect(ctx context.Context) error {
 		for _, sym := range root_syms {
 			sym := sym
 			psg.Go(func() error {
-				c.processSymbol(ctx, sym, 1)
+				c.runSafe("processSymbol", func() { c.processSymbol(ctx, sym, 1) })
 				return nil
 			})
 		}
@@ -526,7 +726,7 @@ func (c *Collector) Collect(ctx context.Context) error {
 	for _, sym := range entity_syms {
 		sym := sym
 		deg.Go(func() error {
-			c.collectDepsForEntity(ctx, sym)
+			c.runSafe("collectDepsForEntity", func() { c.collectDepsForEntity(ctx, sym) })
 			return nil
 		})
 	}
@@ -556,13 +756,15 @@ func (c *Collector) Collect(ctx context.Context) error {
 		for _, sym := range uniq {
 			sym := sym
 			eg.Go(func() error {
-				if len(sym.Tokens) == 0 {
-					tokens, err := c.cli.SemanticTokens(ctx, sym.Location)
-					if err == nil {
-						sym.Tokens = tokens
+				c.runSafe("collectDepsForEntity(ext)", func() {
+					if len(sym.Tokens) == 0 {
+						tokens, err := c.cli.SemanticTokens(ctx, sym.Location)
+						if err == nil {
+							sym.Tokens = tokens
+						}
 					}
-				}
-				c.collectDepsForEntity(ctx, sym)
+					c.collectDepsForEntity(ctx, sym)
+				})
 				return nil
 			})
 		}
@@ -2625,13 +2827,15 @@ func (c *Collector) collectImpl(ctx context.Context, sym *DocumentSymbol, depth 
 	if impl == "" || len(impl) < len(sym.Name) {
 		impl = fmt.Sprintf("class %s {\n", sym.Name)
 	}
-	// C++ multi-inheritance: pick up additional base classes via
-	// typeHierarchy. clangd doesn't return supertypes for dependent
-	// template bases (`class Foo : public Tmpl<X,Y>`), so those edges
-	// will simply be absent — accepting that trade-off keeps the parser
-	// purely LSP-based with no text fallback.
+	// C++ inheritance: resolve base classes via LSP. typeHierarchy handles
+	// concrete (non-dependent) bases; it does NOT report dependent template
+	// bases (`class Foo : public Tmpl<X,Y>`), so we additionally read the
+	// base specifiers from clangd's textDocument/ast and resolve each via
+	// textDocument/definition (collectCppBasesViaAST). Both feed
+	// addImplementsRel, which dedups — purely LSP, no text fallback.
 	if c.Language == uniast.Cpp {
 		c.collectCppBasesViaTypeHierarchy(ctx, sym)
+		c.collectCppBasesViaAST(ctx, sym)
 	}
 
 	// search all methods — snapshot c.syms first so we hold mu only briefly,

--- a/lang/collect/export.go
+++ b/lang/collect/export.go
@@ -274,7 +274,11 @@ func (c *Collector) Export(ctx context.Context) (*uniast.Repository, error) {
 	log.Info("Export: exporting %d symbols...\n", len(c.syms))
 	visited := make(map[*DocumentSymbol]*uniast.Identity)
 	for _, symbol := range c.syms {
-		_, _ = c.exportSymbol(&repo, symbol, "", visited)
+		symbol := symbol
+		// recover per-symbol: a panic while exporting one symbol (e.g. a
+		// degenerate range tripping an out-of-range deep in fileLine) skips
+		// that symbol instead of aborting the whole export. "崩了就跳过".
+		c.runSafe("exportSymbol", func() { _, _ = c.exportSymbol(&repo, symbol, "", visited) })
 	}
 
 	// Synthesize inherited methods per derived class so the call graph can

--- a/lang/cpp/lib.go
+++ b/lang/cpp/lib.go
@@ -29,13 +29,15 @@ func InstallLanguageServer() (string, error) {
 }
 
 func GetDefaultLSP() (lang uniast.Language, name string) {
-	// background-index=false: clangd's persisted index only covers files in
-	// compile_commands.json (the project's own TUs), a small slice of the
-	// cross-TU work abcoder triggers. Disabling it skips disk writes and
-	// background indexer scheduling overhead.
+	// background-index=true: build clangd's persisted cross-TU index so
+	// definition/references/typeHierarchy queries hit the index instead of
+	// re-parsing TUs on demand. The persisted index survives the LSPClient's
+	// crash-restarts (loaded from disk, incremental), so a restart doesn't
+	// re-index from scratch. Heavier upfront + more disk, but speeds the
+	// per-symbol query storm on large workspaces.
 	// pch-storage=disk: keeps preambles on disk (clangd cleans them on
 	// graceful exit). memory mode is ~17% faster but doubles peak RSS.
-	return uniast.Cpp, "clangd-18 --background-index=false --pch-storage=disk -j=32 --clang-tidy=false"
+	return uniast.Cpp, "clangd-18 --background-index=true --pch-storage=disk -j=32 --clang-tidy=false"
 }
 
 func CheckRepo(repo string) (string, time.Duration) {

--- a/lang/lsp/client.go
+++ b/lang/lsp/client.go
@@ -57,6 +57,19 @@ type LSPClient struct {
 
 	ClientOptions
 	LspOptions map[string]string
+
+	// --- restart resilience: clangd can segfault (e.g. in typeParents on
+	// pathological template typeHierarchy), which closes the jsonrpc2 conn
+	// and would otherwise make every later request fail forever. connMu
+	// guards swapping the live Conn/lspHandler/gen during a respawn;
+	// in-flight callers keep using their captured (now-old) conn pointer,
+	// which stays valid (only the field write is synchronized). ---
+	connMu      sync.RWMutex
+	gen         uint64
+	repoURI     DocumentURI
+	autoRestart bool // respawn the server on connection loss (C++ only)
+	restartMu   sync.Mutex
+	restarts    int
 }
 
 type ClientOptions struct {
@@ -84,6 +97,12 @@ func NewLSPClient(repo string, openfile string, wait time.Duration, opts ClientO
 	cli.provider = GetProvider(opts.Language)
 	cli.Verbose = opts.Verbose
 
+	// restart resilience: remember how to respawn, enable for C++ (the only
+	// language whose server is known to crash mid-parse). gen starts at 1.
+	cli.repoURI = NewURI(repo)
+	cli.autoRestart = opts.Language == uniast.Cpp
+	cli.gen = 1
+
 	if openfile != "" {
 		_, err := cli.DidOpen(context.Background(), NewURI(openfile))
 		if err != nil {
@@ -97,8 +116,126 @@ func NewLSPClient(repo string, openfile string, wait time.Duration, opts ClientO
 }
 
 func (c *LSPClient) Close() error {
-	c.lspHandler.Close()
-	return c.Conn.Close()
+	c.connMu.RLock()
+	conn := c.Conn
+	h := c.lspHandler
+	c.connMu.RUnlock()
+	if h != nil {
+		h.Close()
+	}
+	if conn != nil {
+		return conn.Close()
+	}
+	return nil
+}
+
+// curConn returns the live connection and its generation under a read lock.
+// Callers capture the pointer and use it without holding the lock; a
+// concurrent restart that swaps c.Conn is safe because the old conn object
+// stays valid (GC-reachable) for the in-flight call.
+func (cli *LSPClient) curConn() (*jsonrpc2.Conn, uint64) {
+	cli.connMu.RLock()
+	defer cli.connMu.RUnlock()
+	return cli.Conn, cli.gen
+}
+
+// Notify shadows the embedded jsonrpc2.Conn.Notify so notifications go
+// through the restart-aware connection accessor (and trigger a respawn if
+// the transport has died).
+func (cli *LSPClient) Notify(ctx context.Context, method string, params any, opts ...jsonrpc2.CallOption) error {
+	conn, gen := cli.curConn()
+	err := conn.Notify(ctx, method, params, opts...)
+	if err != nil && IsConnClosed(err) {
+		cli.maybeRestart(gen)
+	}
+	return err
+}
+
+// IsConnClosed reports whether err means the LSP transport died (server
+// crashed / pipe closed) — unrecoverable on the same connection.
+func IsConnClosed(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, jsonrpc2.ErrClosed) {
+		return true
+	}
+	s := err.Error()
+	return strings.Contains(s, "connection is closed") ||
+		strings.Contains(s, "broken pipe") ||
+		strings.Contains(s, "use of closed network connection")
+}
+
+// maybeRestart respawns the LSP server iff it hasn't already been restarted
+// since the caller captured observedGen. Safe to call from many goroutines
+// that all observed the same dead connection — only the first wins; the rest
+// see a bumped generation and return. After a restart, every cached document
+// is marked not-opened so the next DidOpen re-notifies the fresh server.
+func (cli *LSPClient) maybeRestart(observedGen uint64) {
+	if !cli.autoRestart {
+		return
+	}
+	cli.restartMu.Lock()
+	defer cli.restartMu.Unlock()
+	cli.connMu.RLock()
+	cur := cli.gen
+	cli.connMu.RUnlock()
+	if cur != observedGen {
+		return // already restarted by another goroutine
+	}
+	log.Error("LSP server connection lost; restarting (restart #%d)...", cli.restarts+1)
+	svr, err := startLSPSever(cli.Server, cli.ClientOptions)
+	if err != nil {
+		log.Error("LSP restart: failed to start server: %v", err)
+		return
+	}
+	newcli, err := initLSPClient(context.Background(), svr, cli.repoURI, cli.Verbose, cli.Language, cli.InitializationOptions)
+	if err != nil {
+		log.Error("LSP restart: failed to init server: %v", err)
+		return
+	}
+	cli.connMu.Lock()
+	oldConn := cli.Conn
+	oldH := cli.lspHandler
+	cli.Conn = newcli.Conn
+	cli.lspHandler = newcli.lspHandler
+	if len(newcli.tokenTypes) > 0 {
+		cli.tokenTypes = newcli.tokenTypes
+	}
+	if len(newcli.tokenModifiers) > 0 {
+		cli.tokenModifiers = newcli.tokenModifiers
+	}
+	cli.gen++
+	newGen := cli.gen
+	cli.connMu.Unlock()
+	cli.restarts++
+	cli.resetServerOpened()
+	if oldH != nil {
+		oldH.Close()
+	}
+	if oldConn != nil {
+		_ = oldConn.Close()
+	}
+	log.Error("LSP server restarted (gen=%d).", newGen)
+}
+
+// resetServerOpened marks every cached document as not-yet-opened on the
+// (new) server so DidOpen re-sends textDocument/didOpen after a restart.
+func (cli *LSPClient) resetServerOpened() {
+	cli.filesMu.RLock()
+	fs := make([]*TextDocumentItem, 0, len(cli.files))
+	for _, f := range cli.files {
+		fs = append(fs, f)
+	}
+	cli.filesMu.RUnlock()
+	for _, f := range fs {
+		if f == nil || f.Mu == nil {
+			continue
+		}
+		f.Mu.Lock()
+		f.ServerOpened = false
+		f.Mu.Unlock()
+	}
 }
 
 // Extra wrapper around jsonrpc2 that retries transient RPC failures.
@@ -109,14 +246,24 @@ func (c *LSPClient) Close() error {
 // retry for terminal errors: MethodNotFound (-32601, server doesn't
 // implement the endpoint) and context cancellation (caller bailed).
 func (cli *LSPClient) Call(ctx context.Context, method string, params, result any, opts ...jsonrpc2.CallOption) error {
+	conn, gen := cli.curConn()
 	var raw json.RawMessage
-	err := cli.Conn.Call(ctx, method, params, &raw)
+	err := conn.Call(ctx, method, params, &raw)
+	if err != nil && IsConnClosed(err) {
+		// The server crashed (e.g. clangd segfault in typeParents on a
+		// pathological template typeHierarchy). Retrying on the dead conn
+		// is pointless; respawn it so subsequent symbols keep working, and
+		// surface the error so THIS call is skipped (C++ base collection
+		// falls back to collectCppBasesViaAST).
+		cli.maybeRestart(gen)
+		return err
+	}
 	if err != nil && shouldRetryRPC(err) {
 		raw = nil
 		err = retry.Do(
 			func() error {
 				raw = nil
-				return cli.Conn.Call(ctx, method, params, &raw)
+				return conn.Call(ctx, method, params, &raw)
 			},
 			retry.Context(ctx),
 			retry.Attempts(2), // initial call already happened; 2 more = 3 total
@@ -125,6 +272,10 @@ func (cli *LSPClient) Call(ctx context.Context, method string, params, result an
 			retry.LastErrorOnly(true),
 			retry.RetryIf(shouldRetryRPC),
 		)
+		if err != nil && IsConnClosed(err) {
+			cli.maybeRestart(gen)
+			return err
+		}
 	}
 	if err != nil {
 		return err

--- a/lang/lsp/lsp_methods.go
+++ b/lang/lsp/lsp_methods.go
@@ -470,9 +470,19 @@ func (cli *LSPClient) Locate(id Location) (string, error) {
 		return "", err
 	}
 	text := f.Text
-	// get block text of range
+	// get block text of range. Guard against degenerate ranges: clangd can
+	// report inverted (Start after End) or out-of-bounds ranges for some
+	// tokens (e.g. macro-expanded or deduced `auto` locations). Without this
+	// guard text[start:end] panics with "slice bounds out of range".
+	if id.Range.Start.Line < 0 || id.Range.Start.Line >= len(f.LineCounts) ||
+		id.Range.End.Line < 0 || id.Range.End.Line >= len(f.LineCounts) {
+		return "", nil
+	}
 	start := f.LineCounts[id.Range.Start.Line] + id.Range.Start.Character
 	end := f.LineCounts[id.Range.End.Line] + id.Range.End.Character
+	if start < 0 || end > len(text) || start > end {
+		return "", nil
+	}
 	return text[start:end], nil
 }
 

--- a/lang/lsp/utils.go
+++ b/lang/lsp/utils.go
@@ -41,7 +41,14 @@ func GetDistance(text string, start Position, pos Position) int {
 	lines := utils.CountLinesPooled(text)
 	defer utils.PutCount(lines)
 	// find the line of the position
-	return (*lines)[pos.Line-start.Line] + pos.Character - start.Character
+	l := pos.Line - start.Line
+	// Defensive: out-of-range line (degenerate clangd range) -> -1, which
+	// ChunkHead already treats as "no text". Avoids an index-out-of-range
+	// panic mid-collect/export.
+	if l < 0 || l >= len(*lines) {
+		return -1
+	}
+	return (*lines)[l] + pos.Character - start.Character
 }
 
 // calculate the relative index of a position to a text
@@ -57,6 +64,16 @@ func ChunkHead(text string, textPos Position, pos Position) string {
 func RelativePostionWithLines(lines []int, basePos Position, pos Position) int {
 	// find the line of the position
 	l := pos.Line - basePos.Line
+	// Defensive: clangd can report a position whose line is outside the
+	// cached line table (degenerate / macro-expanded / stale ranges), which
+	// would otherwise panic here with index-out-of-range and abort the whole
+	// parse (seen in both CppSpec.FunctionSymbol during collect and
+	// fileLine→PositionOffset during export). Return -1, the same "unknown
+	// offset" sentinel PositionOffset already produces for invalid input;
+	// callers either guard on `< 0` or just record a -1 offset.
+	if l < 0 || l >= len(lines) {
+		return -1
+	}
 	return lines[l] + pos.Character - basePos.Character
 }
 


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
Make large-workspace C++ parsing resilient to clangd faults instead of aborting the whole run on a single failure:

- lsp/client.go: auto-restart the LSP server (C++ only) when the jsonrpc2 connection dies (clangd segfaults on pathological template typeHierarchy). Generation-counter guarding lets many goroutines observe the same dead conn but only one respawns; cached docs are marked not-opened so DidOpen re-notifies the fresh server. Call/Notify detect conn-closed and trigger it.
- collect.go/export.go: runSafe() recovers per-symbol panics ("崩了就跳过") so one bad symbol is skipped, not fatal; wrap Collect/Export loops.
- lsp_methods.go/utils.go: guard degenerate (inverted/out-of-bounds) clangd ranges in Locate/GetDistance/RelativePostionWithLines to avoid slice panics.
- collect.go: collectCppBasesViaAST resolves dependent template bases (class Foo : public Tmpl<X,Y>) from textDocument/ast, which typeHierarchy cannot expose; cppSymbolAST adds a per-symbol AST path for .cpp out-of-line definitions. typeHierarchy crashes are counted/logged, not disabled.
- cpp/lib.go: enable clangd --background-index for a persisted cross-TU index that survives restarts and speeds the per-symbol query storm.
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
